### PR TITLE
Changed usage formatting and grammar

### DIFF
--- a/source/cli.js
+++ b/source/cli.js
@@ -6,23 +6,16 @@ import fs from 'fs';
 import tty from 'tty';
 
 const usage = () => {
-  console.log(`
-  lineselect is a shell utility to interactively select lines from stdin and output them to stdout.
-  It requires stdin to be a readable pipe.
+  console.log(`lineselect is a shell utility to interactively select lines from stdin and output them to stdout. It requires stdin to be a readable pipe.
 
-  Usage:
-
+Usage:
     some-command | lineselect | some-other-command
-
     or
-
     some-other-command $(some-command | lineselect)
 
-  Example:
-
-    List the 10 largest files, interactively select from them which ones to delete:
-      ls -S *.log | head -n 10 | lineselect | xargs rm
-    `);
+Example:
+    List the 10 largest files, interactively select which ones to delete:
+    ls -S *.log | head -n 10 | lineselect | xargs rm`);
   process.exit(1);
 };
 


### PR DESCRIPTION
I made some modifications to the usage output which I think look a little better.

1. Removes the extra spacing at the top and bottom of the usage
2. Remove extra spacing between lines
3. Simplifies the wording on the example

Before:
<img width="978" alt="Screenshot 2023-07-06 at 12 15 52 PM" src="https://github.com/chfritz/lineselect/assets/2889651/4a39c9f9-6f83-41f4-83d5-9f56de8c6669">

After:
<img width="1263" alt="Screenshot 2023-07-06 at 12 15 29 PM" src="https://github.com/chfritz/lineselect/assets/2889651/49a33bb1-a9cd-45e4-86ba-7750f225aa39">

